### PR TITLE
Improve download chunking

### DIFF
--- a/src/cloudcasting/download.py
+++ b/src/cloudcasting/download.py
@@ -173,9 +173,9 @@ def download_satellite_data(
                 del ds[v].encoding["chunks"]
 
         target_chunks_dict = {
-            "time": 1,
-            "x_geostationary": 100,
-            "y_geostationary": 100,
+            "time": 2,
+            "x_geostationary": -1,
+            "y_geostationary": -1,
             "variable": -1,
         }
 


### PR DESCRIPTION
Resolves #20

In the downloader we were [chunking the data in x and y dimensions in 100x100 pixel patches](https://github.com/alan-turing-institute/cloudcasting/blob/main/src/cloudcasting/download.py#L177-L178). With the default lat-on bounds the image size is 372 x 614 pixels, so 4 x 7 = 28 chunks per timestamp. 

When we access the data, we are always loading all of the 28 spatial chunks. Doing this is likely slower than if we did not chunk the data spatially and so can load the full spatial image from a single zarr chunk on disk. 

**In this pull request we correct this by not chunking in the x and y dimensions.**

Also, when we access the data using the dataloader we select a time slice. Each model will require a different history length, but all models will require the same forecast length of 3 hours at 15 minute sample frequency as defined in the technical specs. This is 12 timestamps. Previously we have used time chunks of size 1 in the downloaded zarr, which means we will always load at least 12 chunks to cover the history and forecast period. In this pull request, I propose that we switch to a time chunk size of 2. This will half the number of chunks we have to load, and half the overhead of handling chunks. The cost of this is that with 12 required timestamps we will on average have to load 13 timestamps worth of data from disk before trimming down to the 12 we require. The performance of this will vary depending on the disk type we are loading (SSD vs HDD) and how many workers we are using. Without doing extensive performance measurements across multiple machines a chunk size of 2 seems like a reasonable assumption

