### PR TITLE
remove types-all

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,7 +38,6 @@ repos:
           - pytest
           - xarray
           - pandas-stubs
-          - types-all
           - typer
           - dask
           - pyproj


### PR DESCRIPTION
Turns out, all the work on fixing the previous errors built up the right env anyway!

Resolves #34.