### PR TITLE
Make SSIM work with NaN tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cloudcasting"
-version = "0.2.0"
+version = "0.2.1"
 authors = [
   { name = "cloudcasting Maintainers", email = "nsimpson@turing.ac.uk" },
 ]

--- a/src/cloudcasting/metrics.py
+++ b/src/cloudcasting/metrics.py
@@ -105,7 +105,7 @@ def ssim_single(input: SampleOutputArray, target: SampleOutputArray) -> TimeArra
             use_sample_covariance=use_sample_covariance,
             sigma=sigma,
             win_size=win_size,
-        )  # type: ignore[no-untyped-call]
+        )
 
         # To avoid edge effects from the Gaussian filter we trim off the border
         trim_width = (win_size - 1) // 2

--- a/src/cloudcasting/metrics.py
+++ b/src/cloudcasting/metrics.py
@@ -1,19 +1,12 @@
 """Metrics for model output evaluation"""
 
 import numpy as np
-from jaxtyping import Float
-from skimage.metrics import structural_similarity
-from torch import Tensor
+from skimage.metrics import structural_similarity  # type: ignore[import-not-found]
 
-# Type aliases for clarity + reuse
-Array = np.ndarray | Tensor  # type: ignore[type-arg]
-SingleArray = Float[Array, "channels time height width"]
-BatchArray = Float[Array, "batch channels time height width"]
-InputArray = SingleArray | BatchArray
-TimeArray = Float[Array, "time"]
+from cloudcasting.types import BatchOutputArray, OutputArray, SampleOutputArray, TimeArray
 
 
-def mae_single(input: SingleArray, target: SingleArray) -> TimeArray:
+def mae_single(input: SampleOutputArray, target: SampleOutputArray) -> TimeArray:
     """Mean absolute error for single (non-batched) image sequences.
 
     Args:
@@ -28,7 +21,7 @@ def mae_single(input: SingleArray, target: SingleArray) -> TimeArray:
     return arr
 
 
-def mae_batch(input: BatchArray, target: BatchArray) -> TimeArray:
+def mae_batch(input: BatchOutputArray, target: BatchOutputArray) -> TimeArray:
     """Mean absolute error for batched image sequences.
 
     Args:
@@ -43,7 +36,7 @@ def mae_batch(input: BatchArray, target: BatchArray) -> TimeArray:
     return arr
 
 
-def mse_single(input: SingleArray, target: SingleArray) -> TimeArray:
+def mse_single(input: SampleOutputArray, target: SampleOutputArray) -> TimeArray:
     """Mean squared error for single (non-batched) image sequences.
 
     Args:
@@ -58,7 +51,7 @@ def mse_single(input: SingleArray, target: SingleArray) -> TimeArray:
     return arr
 
 
-def mse_batch(input: BatchArray, target: BatchArray) -> TimeArray:
+def mse_batch(input: BatchOutputArray, target: BatchOutputArray) -> TimeArray:
     """Mean squared error for batched image sequences.
 
     Args:
@@ -73,7 +66,7 @@ def mse_batch(input: BatchArray, target: BatchArray) -> TimeArray:
     return arr
 
 
-def ssim_single(input: SingleArray, target: SingleArray) -> TimeArray:
+def ssim_single(input: SampleOutputArray, target: SampleOutputArray) -> TimeArray:
     """Computes the Structural Similarity (SSIM) index for single (non-batched) image sequences.
 
     Args:
@@ -124,12 +117,13 @@ def ssim_single(input: SingleArray, target: SingleArray) -> TimeArray:
     return arr
 
 
-def ssim_batch(input: BatchArray, target: BatchArray) -> TimeArray:
+def ssim_batch(input: BatchOutputArray, target: BatchOutputArray) -> TimeArray:
     """Structural similarity for batched image sequences.
 
     Args:
         input: Array of shape [batch, channels, time, height, width]
         target: Array of shape [batch, channels, time, height, width]
+        win_size: Side-length of the sliding window for comparison (must be odd)
 
     Returns:
         Array of SSIM values along the time dimension
@@ -144,7 +138,7 @@ def ssim_batch(input: BatchArray, target: BatchArray) -> TimeArray:
     return arr
 
 
-def _check_input_target_ranges(input: InputArray, target: InputArray) -> None:
+def _check_input_target_ranges(input: OutputArray, target: OutputArray) -> None:
     """Validate input and target arrays are within the 0-1 range.
 
     Args:

--- a/src/cloudcasting/metrics.py
+++ b/src/cloudcasting/metrics.py
@@ -66,9 +66,7 @@ def mse_batch(input: BatchOutputArray, target: BatchOutputArray) -> MetricArray:
     return arr
 
 
-
-def ssim_single(
-    input: SampleOutputArray, target: SampleOutputArray) -> MetricArray:
+def ssim_single(input: SampleOutputArray, target: SampleOutputArray) -> MetricArray:
     """Computes the Structural Similarity (SSIM) index for single (non-batched) image sequences.
 
     Args:
@@ -83,7 +81,7 @@ def ssim_single(
         Image quality assessment: From error visibility to structural similarity.
         IEEE Transactions on Image Processing, 13, 600-612.
         https://ece.uwaterloo.ca/~z70wang/publications/ssim.pdf,
-        DOI: 10.1109/TIP.2003.819861        
+        DOI: 10.1109/TIP.2003.819861
     """
 
     # This function assumes the data will be in the range 0-1 and will give invalid results if not

--- a/src/cloudcasting/metrics.py
+++ b/src/cloudcasting/metrics.py
@@ -1,12 +1,19 @@
 """Metrics for model output evaluation"""
 
 import numpy as np
-from skimage.metrics import structural_similarity  # type: ignore[import-not-found]
+from jaxtyping import Float
+from skimage.metrics import structural_similarity
+from torch import Tensor
 
-from cloudcasting.types import BatchOutputArray, OutputArray, SampleOutputArray, TimeArray
+# Type aliases for clarity + reuse
+Array = np.ndarray | Tensor  # type: ignore[type-arg]
+SingleArray = Float[Array, "channels time height width"]
+BatchArray = Float[Array, "batch channels time height width"]
+InputArray = SingleArray | BatchArray
+TimeArray = Float[Array, "time"]
 
 
-def mae_single(input: SampleOutputArray, target: SampleOutputArray) -> TimeArray:
+def mae_single(input: SingleArray, target: SingleArray) -> TimeArray:
     """Mean absolute error for single (non-batched) image sequences.
 
     Args:
@@ -21,7 +28,7 @@ def mae_single(input: SampleOutputArray, target: SampleOutputArray) -> TimeArray
     return arr
 
 
-def mae_batch(input: BatchOutputArray, target: BatchOutputArray) -> TimeArray:
+def mae_batch(input: BatchArray, target: BatchArray) -> TimeArray:
     """Mean absolute error for batched image sequences.
 
     Args:
@@ -36,7 +43,7 @@ def mae_batch(input: BatchOutputArray, target: BatchOutputArray) -> TimeArray:
     return arr
 
 
-def mse_single(input: SampleOutputArray, target: SampleOutputArray) -> TimeArray:
+def mse_single(input: SingleArray, target: SingleArray) -> TimeArray:
     """Mean squared error for single (non-batched) image sequences.
 
     Args:
@@ -51,7 +58,7 @@ def mse_single(input: SampleOutputArray, target: SampleOutputArray) -> TimeArray
     return arr
 
 
-def mse_batch(input: BatchOutputArray, target: BatchOutputArray) -> TimeArray:
+def mse_batch(input: BatchArray, target: BatchArray) -> TimeArray:
     """Mean squared error for batched image sequences.
 
     Args:
@@ -66,48 +73,63 @@ def mse_batch(input: BatchOutputArray, target: BatchOutputArray) -> TimeArray:
     return arr
 
 
-def ssim_single(
-    input: SampleOutputArray, target: SampleOutputArray, win_size: int | None = None
-) -> TimeArray:
-    """Structural similarity for single (non-batched) image sequences.
+def ssim_single(input: SingleArray, target: SingleArray) -> TimeArray:
+    """Computes the Structural Similarity (SSIM) index for single (non-batched) image sequences.
 
     Args:
         input: Array of shape [channels, time, height, width]
         target: Array of shape [channels, time, height, width]
-        win_size: Side-length of the sliding window for comparison (must be odd)
 
     Returns:
         Array of SSIM values along the time dimension
+
+    References:
+        Wang, Z., Bovik, A. C., Sheikh, H. R., & Simoncelli, E. P. (2004).
+        Image quality assessment: From error visibility to structural similarity.
+        IEEE Transactions on Image Processing, 13, 600-612.
+        https://ece.uwaterloo.ca/~z70wang/publications/ssim.pdf,
+        DOI: 10.1109/TIP.2003.819861
     """
+
     # This function assumes the data will be in the range 0-1 and will give invalid results if not
     _check_input_target_ranges(input, target)
+
+    # The following param setting match Wang et. al. 2004
+    gaussian_weights = True
+    use_sample_covariance = False
+    sigma = 1.5
+    win_size = 11
+
     ssim_seq = []
     for i_t in range(input.shape[1]):
-        # Calculate the SSIM array for this time step
         _, ssim_array = structural_similarity(
-            input[:, i_t, :, :],
-            target[:, i_t, :, :],
+            input[:, i_t],
+            target[:, i_t],
             data_range=1,
             channel_axis=0,
             full=True,
+            gaussian_weights=gaussian_weights,
+            use_sample_covariance=use_sample_covariance,
+            sigma=sigma,
             win_size=win_size,
-        )
-        # Take the mean of the SSIM array over channels, height, and width
-        ssim_seq.append(np.nanmean(ssim_array, axis=(0, 1, 2)))
+        )  # type: ignore[no-untyped-call]
+
+        # To avoid edge effects from the Gaussian filter we trim off the border
+        trim_width = (win_size - 1) // 2
+        ssim_array = ssim_array[:, trim_width:-trim_width, trim_width:-trim_width]
+
+        ssim_seq.append(np.nanmean(ssim_array))
 
     arr: TimeArray = np.stack(ssim_seq, axis=0)
     return arr
 
 
-def ssim_batch(
-    input: BatchOutputArray, target: BatchOutputArray, win_size: int | None = None
-) -> TimeArray:
+def ssim_batch(input: BatchArray, target: BatchArray) -> TimeArray:
     """Structural similarity for batched image sequences.
 
     Args:
         input: Array of shape [batch, channels, time, height, width]
         target: Array of shape [batch, channels, time, height, width]
-        win_size: Side-length of the sliding window for comparison (must be odd)
 
     Returns:
         Array of SSIM values along the time dimension
@@ -117,12 +139,12 @@ def ssim_batch(
 
     ssim_samples = []
     for i_b in range(input.shape[0]):
-        ssim_samples.append(ssim_single(input[i_b], target[i_b], win_size=win_size))
+        ssim_samples.append(ssim_single(input[i_b], target[i_b]))
     arr: TimeArray = np.stack(ssim_samples, axis=0).mean(axis=0)
     return arr
 
 
-def _check_input_target_ranges(input: OutputArray, target: OutputArray) -> None:
+def _check_input_target_ranges(input: InputArray, target: InputArray) -> None:
     """Validate input and target arrays are within the 0-1 range.
 
     Args:

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -88,7 +88,6 @@ def test_calc_mse_batch(zeros_batch, ones_batch):
     assert (result == 4).all()
 
 
-@pytest.mark.skip(reason="Currently unstable with NaNs")
 def test_calc_ssim_sample(zeros_sample, ones_sample, zeros_missing_sample):
     result = ssim_single(zeros_sample, zeros_sample)
     np.testing.assert_almost_equal(result, 1, decimal=4)
@@ -99,11 +98,10 @@ def test_calc_ssim_sample(zeros_sample, ones_sample, zeros_missing_sample):
     result = ssim_single(zeros_sample, ones_sample)
     np.testing.assert_almost_equal(result, 0, decimal=4)
 
-    result = ssim_single(zeros_sample, zeros_missing_sample, win_size=3)
+    result = ssim_single(zeros_sample, zeros_missing_sample)
     np.testing.assert_almost_equal(result, 1, decimal=4)
 
 
-@pytest.mark.skip(reason="Currently unstable with NaNs")
 def test_calc_ssim_batch(zeros_batch, ones_batch):
     result = ssim_batch(zeros_batch, zeros_batch)
     np.testing.assert_almost_equal(result, 1, decimal=4)


### PR DESCRIPTION
**Note: edited since first posted**

By changing some of the parameters used in the `structural_similarity()` function from `skimage`, we can get the SSIM calculation to work with the examples in our tests which contain NaNs in the target image. 

In working on this, we discovered that the old configuration of `structural_similarity()` only fails if there is a NaN in the top left (i.e. at `y[..., 0, 0]`) but doesn't fail if there are NaNs elsewhere. So we had only caught an edge case with our tests.

However, I believe that this new configuration of `structural_similarity()` which passes with our current tests is still better because it is more robust and more referenceable. The new configuration of `structural_similarity()` matches that used in the [original paper ](https://ieeexplore.ieee.org/document/1284395). We use the hint in the `structural_similarity()` [docstring](https://scikit-image.org/docs/stable/api/skimage.metrics.html#skimage.metrics.structural_similarity) to match to the original paper.


This solves #11