### PR TITLE
Expose per-channel metric information in wandb

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Install ffmpeg on macOS
         if: runner.os == 'macOS'
         run: |
-          brew install ffmpeg
+          brew install ffmpeg omp
 
       - name: Install package
         run: python -m pip install .[dev]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Install ffmpeg on macOS
         if: runner.os == 'macOS'
         run: |
-          brew install ffmpeg llvm libomp
+          brew install ffmpeg
 
       - name: Install package
         run: python -m pip install .[dev]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Install ffmpeg on macOS
         if: runner.os == 'macOS'
         run: |
-          brew install ffmpeg omp
+          brew install ffmpeg llvm libomp
 
       - name: Install package
         run: python -m pip install .[dev]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "dask",
     "pyresample",
     "pyproj",
+    "pykdtree<=1.3.12",    # for macOS
     "ocf-blosc2>=0.0.10",  # for no-import codec register
     "typer",
     "lightning",

--- a/src/cloudcasting/metrics.py
+++ b/src/cloudcasting/metrics.py
@@ -3,7 +3,7 @@
 import numpy as np
 from skimage.metrics import structural_similarity  # type: ignore[import-not-found]
 
-from cloudcasting.types import BatchOutputArray, OutputArray, SampleOutputArray, MetricArray
+from cloudcasting.types import BatchOutputArray, MetricArray, OutputArray, SampleOutputArray
 
 
 def mae_single(input: SampleOutputArray, target: SampleOutputArray) -> MetricArray:

--- a/src/cloudcasting/metrics.py
+++ b/src/cloudcasting/metrics.py
@@ -3,10 +3,10 @@
 import numpy as np
 from skimage.metrics import structural_similarity  # type: ignore[import-not-found]
 
-from cloudcasting.types import BatchOutputArray, OutputArray, SampleOutputArray, TimeArray
+from cloudcasting.types import BatchOutputArray, OutputArray, SampleOutputArray, MetricArray
 
 
-def mae_single(input: SampleOutputArray, target: SampleOutputArray) -> TimeArray:
+def mae_single(input: SampleOutputArray, target: SampleOutputArray) -> MetricArray:
     """Mean absolute error for single (non-batched) image sequences.
 
     Args:
@@ -14,14 +14,14 @@ def mae_single(input: SampleOutputArray, target: SampleOutputArray) -> TimeArray
         target: Array of shape [channels, time, height, width]
 
     Returns:
-        Array of MAE values along the time dimension
+        Array of MAE values of shape [channel, time]
     """
     absolute_error = np.abs(input - target)
-    arr: TimeArray = np.nanmean(absolute_error, axis=(0, 2, 3))
+    arr: MetricArray = np.nanmean(absolute_error, axis=(2, 3))
     return arr
 
 
-def mae_batch(input: BatchOutputArray, target: BatchOutputArray) -> TimeArray:
+def mae_batch(input: BatchOutputArray, target: BatchOutputArray) -> MetricArray:
     """Mean absolute error for batched image sequences.
 
     Args:
@@ -29,14 +29,14 @@ def mae_batch(input: BatchOutputArray, target: BatchOutputArray) -> TimeArray:
         target: Array of shape [batch, channels, time, height, width]
 
     Returns:
-        Array of MAE values along the time dimension
+        Array of MAE values of shape [channel, time]
     """
     absolute_error = np.abs(input - target)
-    arr: TimeArray = np.nanmean(absolute_error, axis=(0, 1, 3, 4))
+    arr: MetricArray = np.nanmean(absolute_error, axis=(0, 3, 4))
     return arr
 
 
-def mse_single(input: SampleOutputArray, target: SampleOutputArray) -> TimeArray:
+def mse_single(input: SampleOutputArray, target: SampleOutputArray) -> MetricArray:
     """Mean squared error for single (non-batched) image sequences.
 
     Args:
@@ -44,14 +44,14 @@ def mse_single(input: SampleOutputArray, target: SampleOutputArray) -> TimeArray
         target: Array of shape [channels, time, height, width]
 
     Returns:
-        Array of MSE values along the time dimension
+        Array of MSE values of shape [channel, time]
     """
     square_error = (input - target) ** 2
-    arr: TimeArray = np.nanmean(square_error, axis=(0, 2, 3))
+    arr: MetricArray = np.nanmean(square_error, axis=(2, 3))
     return arr
 
 
-def mse_batch(input: BatchOutputArray, target: BatchOutputArray) -> TimeArray:
+def mse_batch(input: BatchOutputArray, target: BatchOutputArray) -> MetricArray:
     """Mean squared error for batched image sequences.
 
     Args:
@@ -59,16 +59,16 @@ def mse_batch(input: BatchOutputArray, target: BatchOutputArray) -> TimeArray:
         target: Array of shape [batch, channels, time, height, width]
 
     Returns:
-        Array of MSE values along the time dimension
+        Array of MSE values of shape [channel, time]
     """
     square_error = (input - target) ** 2
-    arr: TimeArray = np.nanmean(square_error, axis=(0, 1, 3, 4))
+    arr: MetricArray = np.nanmean(square_error, axis=(0, 3, 4))
     return arr
 
 
 def ssim_single(
     input: SampleOutputArray, target: SampleOutputArray, win_size: int | None = None
-) -> TimeArray:
+) -> MetricArray:
     """Structural similarity for single (non-batched) image sequences.
 
     Args:
@@ -77,7 +77,7 @@ def ssim_single(
         win_size: Side-length of the sliding window for comparison (must be odd)
 
     Returns:
-        Array of SSIM values along the time dimension
+        Array of SSIM values of shape [channel, time]
     """
     # This function assumes the data will be in the range 0-1 and will give invalid results if not
     _check_input_target_ranges(input, target)
@@ -93,15 +93,15 @@ def ssim_single(
             win_size=win_size,
         )
         # Take the mean of the SSIM array over channels, height, and width
-        ssim_seq.append(np.nanmean(ssim_array, axis=(0, 1, 2)))
-
-    arr: TimeArray = np.stack(ssim_seq, axis=0)
+        ssim_seq.append(np.nanmean(ssim_array, axis=(1, 2)))
+    # stack along channel dimension
+    arr: MetricArray = np.stack(ssim_seq, axis=1)
     return arr
 
 
 def ssim_batch(
     input: BatchOutputArray, target: BatchOutputArray, win_size: int | None = None
-) -> TimeArray:
+) -> MetricArray:
     """Structural similarity for batched image sequences.
 
     Args:
@@ -110,7 +110,7 @@ def ssim_batch(
         win_size: Side-length of the sliding window for comparison (must be odd)
 
     Returns:
-        Array of SSIM values along the time dimension
+        Array of SSIM values of shape [channel, time]
     """
     # This function assumes the data will be in the range 0-1 and will give invalid results if not
     _check_input_target_ranges(input, target)
@@ -118,7 +118,7 @@ def ssim_batch(
     ssim_samples = []
     for i_b in range(input.shape[0]):
         ssim_samples.append(ssim_single(input[i_b], target[i_b], win_size=win_size))
-    arr: TimeArray = np.stack(ssim_samples, axis=0).mean(axis=0)
+    arr: MetricArray = np.stack(ssim_samples, axis=0).mean(axis=0)
     return arr
 
 

--- a/src/cloudcasting/types.py
+++ b/src/cloudcasting/types.py
@@ -1,4 +1,6 @@
 __all__ = (
+    "MetricArray",
+    "ChannelArray",
     "TimeArray",
     "SampleInputArray",
     "BatchInputArray",
@@ -15,6 +17,8 @@ from jaxtyping import Float as Float32
 # Type aliases for clarity + reuse
 Array = npt.NDArray[np.float32]  # the type arg is ignored by jaxtyping, but is here for clarity
 TimeArray = Float32[Array, "time"]
+MetricArray = Float32[Array, "channels time"]
+ChannelArray = Float32[Array, "channels"]
 
 SampleInputArray = Float32[Array, "channels time height width"]
 BatchInputArray = Float32[Array, "batch channels time height width"]

--- a/src/cloudcasting/validation.py
+++ b/src/cloudcasting/validation.py
@@ -192,7 +192,7 @@ def score_model_on_all_metrics(
 
         for metric_name, metric_func in metric_funcs.items():
             metrics[metric_name].append(metric_func(y_hat, y))
-        
+
         if batch_limit is not None and i >= batch_limit:
             break
 
@@ -334,26 +334,26 @@ def validate(
         dtype=np.float32,
     )
 
-    for metric_name, metric_array in horizon_metrics_dict.items():
+    for metric_name, horizon_array in horizon_metrics_dict.items():
         log_horizon_metric_plot_to_wandb(
             horizon_mins=horizon_mins,
-            metric_values=metric_array,
+            metric_values=horizon_array,
             plot_name=f"{metric_name}-horizon",
             metric_name=metric_name,
         )
 
     # Log the mean metrics to wandb
-    for metric_name, metric_value in mean_metrics_dict.items():
+    for metric_name, value in mean_metrics_dict.items():
         log_mean_metrics_to_wandb(
-            metric_value=metric_value,
+            metric_value=value,
             plot_name=f"{metric_name}-mean",
             metric_name=metric_name,
         )
 
     # Log mean metrics per-channel
-    for metric_name, metric_value in channel_metrics_dict.items():
+    for metric_name, channel_array in channel_metrics_dict.items():
         log_per_channel_metrics_to_wandb(
-            metric_value=metric_value,
+            metric_value=channel_array,
             plot_name=f"{metric_name}-mean",
             channel_names=names,
         )

--- a/src/cloudcasting/validation.py
+++ b/src/cloudcasting/validation.py
@@ -192,11 +192,11 @@ def score_model_on_all_metrics(
 
         for metric_name, metric_func in metric_funcs.items():
             metrics[metric_name].append(metric_func(y_hat, y))
-
+        
         if batch_limit is not None and i >= batch_limit:
             break
 
-    res = {k: np.mean(v, axis=0) for k, v in metrics.items()}
+    res = {k: np.mean(np.array(v), axis=0) for k, v in metrics.items()}
 
     num_timesteps = FORECAST_HORIZON_MINUTES // DATA_INTERVAL_SPACING_MINUTES
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -28,7 +28,7 @@ def test_score_model_on_all_metrics(model, val_sat_zarr_path, nan_to_num):
     )
 
     # Call the score_model_on_all_metrics function
-    metrics_dict, _channels = score_model_on_all_metrics(
+    metrics_dict, channels = score_model_on_all_metrics(
         model=model,
         valid_dataset=valid_dataset,
         batch_size=2,
@@ -46,6 +46,7 @@ def test_score_model_on_all_metrics(model, val_sat_zarr_path, nan_to_num):
     for metric_name, metric_array in metrics_dict.items():
         # check all the items have the expected shape
         assert metric_array.shape == (
+            len(channels),
             NUM_FORECAST_STEPS,
         ), f"Metric {metric_name} has the wrong shape"
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -28,7 +28,7 @@ def test_score_model_on_all_metrics(model, val_sat_zarr_path, nan_to_num):
     )
 
     # Call the score_model_on_all_metrics function
-    metrics_dict = score_model_on_all_metrics(
+    metrics_dict, _channels = score_model_on_all_metrics(
         model=model,
         valid_dataset=valid_dataset,
         batch_size=2,


### PR DESCRIPTION
Changes all metrics to not reduce over the channel dimension, and adds a new bar chart that summarises the per-channel average metrics.

Closes #53