### PR TITLE
Link actions badge to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Distributed under the terms of the [MIT license](LICENSE).
 
 
 <!-- prettier-ignore-start -->
-[actions-badge]:            https://github.com/climetrend/cloudcasting/workflows/CI/badge.svg
+[actions-badge]:            https://github.com/climetrend/cloudcasting/workflows/CI/badge.svg?branch=main
 [actions-link]:             https://github.com/climetrend/cloudcasting/actions
 [pypi-link]:                https://pypi.org/project/cloudcasting/
 [pypi-platforms]:           https://img.shields.io/pypi/pyversions/cloudcasting


### PR DESCRIPTION
Currently the github CI actions badge on the readme will show failing if the tests fail on any of the branches. I think this should be tidied to the main branch, following: https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/monitoring-workflows/adding-a-workflow-status-badge#using-the-branch-parameter 

Pretty sure this change should solve the problem