### PR TITLE
Version via Git tags only

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,11 @@
 [build-system]
-requires = ["setuptools>=61"]
+requires = ["setuptools>=61", "setuptools_scm[toml]>=7"]
 build-backend = "setuptools.build_meta"
 
 
 [project]
 name = "cloudcasting"
-version = "0.3.0"
+dynamic = ["version"]
 authors = [
   { name = "cloudcasting Maintainers", email = "nsimpson@turing.ac.uk" },
 ]
@@ -59,6 +59,9 @@ dev = [
 
 [tool.setuptools.package-data]
 "cloudcasting" = ["data/*.zip"]
+
+[tool.setuptools_scm]
+write_to = "src/cloudcasting/_version.py"
 
 [project.scripts]
 cloudcasting = "cloudcasting.cli:app"

--- a/src/cloudcasting/__init__.py
+++ b/src/cloudcasting/__init__.py
@@ -4,8 +4,6 @@ cloudcasting: Tooling and infrastructure to enable cloud nowcasting.
 
 from __future__ import annotations
 
-from importlib.metadata import version
-
 from jaxtyping import install_import_hook
 
 # Any module imported inside this `with` block, whose
@@ -19,6 +17,8 @@ with install_import_hook("cloudcasting", "typeguard.typechecked"):
 
 from cloudcasting import cli, dataset, download, metrics
 
+from ._version import version as __version__
+
 __all__ = (
     "__version__",
     "download",
@@ -28,4 +28,3 @@ __all__ = (
     "validation",
     "metrics",
 )
-__version__ = version(__name__)

--- a/src/cloudcasting/_version.pyi
+++ b/src/cloudcasting/_version.pyi
@@ -1,0 +1,1 @@
+version: str


### PR DESCRIPTION
Using [`setuptools_scm`](https://setuptools-scm.readthedocs.io/en/stable/). Makes our versioning workflow use git tags, which we can control through GitHub releases.

The workflow is:
- PR(s) get merged
- Make a github release with a new tag (+ auto-generate release notes)
- Version will be implicitly updated once you run `git pull` after the tag creation!
  - you can check this with `python -c "import cloudcasting; print(cloudcasting.__version__)"` :)
