### PR TITLE
More proper multiple zarr loading and bug fix for history length

### DIFF
--- a/src/cloudcasting/dataset.py
+++ b/src/cloudcasting/dataset.py
@@ -43,14 +43,15 @@ def load_satellite_zarrs(zarr_path: list[str] | tuple[str] | str) -> xr.Dataset:
     """
 
     if isinstance(zarr_path, list | tuple):
-        ds = xr.combine_nested(
+        ds = xr.concat(
             [xr.open_dataset(path, engine="zarr", chunks="auto") for path in zarr_path],
-            concat_dim="time",
+            dim="time",
+            coords="minimal",
+            compat="identical",
             combine_attrs="override",
-            join="override",
-        )
+        ).sortby("time")
     else:
-        ds = xr.open_dataset(zarr_path, engine="zarr")
+        ds = xr.open_dataset(zarr_path, engine="zarr", chunks="auto").sortby("time")
 
     return ds
 

--- a/src/cloudcasting/validation.py
+++ b/src/cloudcasting/validation.py
@@ -288,7 +288,7 @@ def validate(
     # Set up the validation dataset
     valid_dataset = ValidationSatelliteDataset(
         zarr_path=data_path,
-        history_mins=model.history_steps * DATA_INTERVAL_SPACING_MINUTES,
+        history_mins=(model.history_steps - 1) * DATA_INTERVAL_SPACING_MINUTES,
         forecast_mins=FORECAST_HORIZON_MINUTES,
         sample_freq_mins=DATA_INTERVAL_SPACING_MINUTES,
         nan_to_num=nan_to_num,


### PR DESCRIPTION
This PR includes two separate things I've been using locally

- First and most importantly, we were calculating the wrong history mins for the validation dataloader from the number of history steps the model requires. If `history_mins=0` then the dataset returns a single satellite timestep at time t0 for the input X. This corresponds to `history_steps=1`. 
- I think it is better practice to use the `xr.concat()` function for merging multiple datasets since we are only merging along a single axis. Plus previously we were not sorting by time which could be an issue if the user passed in yearly satellite zarrs not in order of increasing years 