### PR TITLE
Temporary pinning of jaxtyping

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,10 +39,10 @@ dependencies = [
     "typer",
     "lightning",
     "torch>=2.3.0",  # needed for numpy 2.0
-    "jaxtyping<=0.2.34",
+    "jaxtyping<=0.2.34", # currently >0.2.34 causing errors
     "wandb",
     "tqdm",
-    "moviepy>=1.0.3",
+    "moviepy==1.0.3", # currently >1.0.3 not working with wandb
     "imageio>=2.35.1",
     "numpy <2.1.0",  # https://github.com/wandb/wandb/issues/8166
     "chex",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     "typer",
     "lightning",
     "torch>=2.3.0",  # needed for numpy 2.0
-    "jaxtyping",
+    "jaxtyping<=0.2.34",
     "wandb",
     "tqdm",
     "moviepy>=1.0.3",


### PR DESCRIPTION
The latest update of jaxtyping to 0.2.36 is causing issues - see #81. This is a temporary fix to get cloudcasting working again