### PR TITLE
feat: validate data paths in SatelliteDataModule initialization

### DIFF
--- a/src/cloudcasting/dataset.py
+++ b/src/cloudcasting/dataset.py
@@ -10,6 +10,7 @@ import io
 import pkgutil
 from datetime import datetime, timedelta
 from typing import TypedDict
+import os
 
 import numpy as np
 import pandas as pd
@@ -342,6 +343,9 @@ class SatelliteDataModule(LightningDataModule):
         self.forecast_mins = forecast_mins
         self.sample_freq_mins = sample_freq_mins
 
+        # Validate data paths at instantiation
+        self._validate_data_paths()
+
         self._common_dataloader_kwargs = DataloaderArgs(
             batch_size=batch_size,
             sampler=None,
@@ -357,6 +361,21 @@ class SatelliteDataModule(LightningDataModule):
 
         self.nan_to_num = nan_to_num
         self.variables = variables
+
+    def _validate_data_paths(self) -> None:
+        """Validate that all data paths exist at instantiation.
+        
+        Raises:
+            FileNotFoundError: If any of the data paths do not exist.
+        """
+        if isinstance(self.zarr_path, str):
+            paths = [self.zarr_path]
+        else:
+            paths = self.zarr_path
+            
+        for path in paths:
+            if not os.path.exists(path):
+                raise FileNotFoundError(f"Data path does not exist: {path}")
 
     def _make_dataset(
         self, start_date: str | None, end_date: str | None, preshuffle: bool = False


### PR DESCRIPTION
# Validate data paths in SatelliteDataModule initialization

This PR addresses issue #18 by adding validation of data paths during the initialization of the `SatelliteDataModule` class.

## Changes
- Added a new `_validate_data_paths()` method to check if all provided data paths exist
- Added validation call in `__init__` after setting the `zarr_path` attribute
- Added proper error handling with descriptive messages

## Testing
The changes ensure that invalid data paths are caught early during initialization rather than when the dataloader methods are called. This provides better error messages and prevents potential issues from surfacing later in the training process.

## Impact
This change improves the robustness of the code by failing fast when data paths are invalid, making it easier to debug configuration issues.